### PR TITLE
fix: Update jupyter-eval-region invocation

### DIFF
--- a/python-cell.el
+++ b/python-cell.el
@@ -147,7 +147,7 @@ the command `python-cell-mode' to turn Python-Cell mode on."
     (goto-char (point-max))))
 
 
-(declare-function jupyter-eval-region "jupyter-client.el" (jupyter-eval-region beg end))
+(declare-function jupyter-eval-region "jupyter-client.el" (jupyter-eval-region nil beg end))
 (defun python-cell-shell-send-cell ()
   "Send the cell the cursor is in to the inferior Python process."
   (interactive)
@@ -161,7 +161,7 @@ the command `python-cell-mode' to turn Python-Cell mode on."
     ;; (activate-mark)))
     (pcase python-cell-run-region-fn
       ('shell (python-shell-send-region start end))
-      ('jupyter (jupyter-eval-region start end)))))
+      ('jupyter (jupyter-eval-region nil start end)))))
 
 (defun python-cell-run-till-point ()
   "Run all cells until point, not including the cell point is in."


### PR DESCRIPTION
To match upstream function signature changes in [32376a2](https://github.com/emacs-jupyter/jupyter/commit/32376a22b57f5b1709aec9662543ab9a9d1a602a).